### PR TITLE
Rydding i xsd-skjema

### DIFF
--- a/Schema/V2/no.ks.fiks.matrikkelfoering.v2.grunnlag.xsd
+++ b/Schema/V2/no.ks.fiks.matrikkelfoering.v2.grunnlag.xsd
@@ -4,7 +4,7 @@
   <!-- -manually made VarmefordelingListe, EnergiforsyningTypeListe 31.03.2022-->
   <!-- -manually fixed types 31.03.2022-->
   <!-- -manually fixed references to Geometri 31.03.2022-->
-  <xs:import namespace="http://rep.geointegrasjon.no/Felles/Geometri/xml.schema/2012.01.31" schemaLocation="http://rep.geointegrasjon.no/Felles/Geometri/xml.schema/2012.01.31/giFellesGeometri20120131.xsd"/>
+  <xs:import namespace="http://rep.geointegrasjon.no/Felles/Geometri/xml.schema/2012.01.31" schemaLocation="giFellesGeometri20120131.xsd"/>
   <xs:element name="Adresse" type="mf:AdresseType"/>
   <xs:complexType name="AdresseListe">
     <xs:sequence>

--- a/Schema/V2/no.ks.fiks.matrikkelfoering.v2.kvittering.xsd
+++ b/Schema/V2/no.ks.fiks.matrikkelfoering.v2.kvittering.xsd
@@ -1,14 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://rep.geointegrasjon.no/Matrikkel/foeringskvittering/v2" xmlns:mf="http://rep.geointegrasjon.no/Matrikkel/foering/v2" elementFormDefault="qualified" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" >
-	
+
 	<xs:element name="KvitteringMatrikkel" type="KvitteringMatrikkelType"/>
 	<xs:element name="Saksnummer" type="SaksnummerType"/>
-
-	<xs:complexType name="KvitteringMatrikkelListe">
-		<xs:sequence>
-			<xs:element name="kvitteringmatrikkel" type="KvitteringMatrikkelType" minOccurs="0" maxOccurs="unbounded"/>
-		</xs:sequence>
-	</xs:complexType>
 
 	<xs:complexType name="KvitteringMatrikkelType">
 		<xs:sequence>
@@ -19,20 +13,20 @@
 			<xs:element name="byggIdent" minOccurs="0" maxOccurs="1" nillable="true" type="mf:ByggIdentListe"/>
 		</xs:sequence>
 	</xs:complexType>
-	
+
 	<xs:complexType name="SaksnummerListe">
 		<xs:sequence>
 			<xs:element name="saksnummer" type="SaksnummerType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
-	
+
 	<xs:complexType name="SaksnummerType">
 		<xs:sequence>
 			<xs:element name="saksaar" minOccurs="1" maxOccurs="1" type="xs:integer"/>
 			<xs:element name="sakssekvensnummer" minOccurs="1" maxOccurs="1" type="xs:integer"/>
 		</xs:sequence>
 	</xs:complexType>
-	
+
 	<xs:simpleType name="StatusTypeType">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="velykket"/>
@@ -41,10 +35,5 @@
 			<xs:enumeration value="manglendeOpplysninger"/>
 		</xs:restriction>
 	</xs:simpleType>
-	
-	<xs:complexType name="StatusTypeListe">
-		<xs:sequence>
-			<xs:element name="statustype" type="StatusTypeType" minOccurs="0" maxOccurs="unbounded"/>
-		</xs:sequence>
-	</xs:complexType>
+
 </xs:schema>

--- a/Schema/V2/no.ks.fiks.matrikkelfoering.v2.kvittering.xsd
+++ b/Schema/V2/no.ks.fiks.matrikkelfoering.v2.kvittering.xsd
@@ -2,13 +2,14 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://rep.geointegrasjon.no/Matrikkel/foeringskvittering/v2" xmlns:mf="http://rep.geointegrasjon.no/Matrikkel/foering/v2" elementFormDefault="qualified" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" >
 	
 	<xs:element name="KvitteringMatrikkel" type="KvitteringMatrikkelType"/>
-	
+	<xs:element name="Saksnummer" type="SaksnummerType"/>
+
 	<xs:complexType name="KvitteringMatrikkelListe">
 		<xs:sequence>
 			<xs:element name="kvitteringmatrikkel" type="KvitteringMatrikkelType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
-	
+
 	<xs:complexType name="KvitteringMatrikkelType">
 		<xs:sequence>
 			<xs:element name="saksnummer" minOccurs="1" maxOccurs="1" type="SaksnummerType"/>
@@ -18,18 +19,20 @@
 			<xs:element name="byggIdent" minOccurs="0" maxOccurs="1" nillable="true" type="mf:ByggIdentListe"/>
 		</xs:sequence>
 	</xs:complexType>
-	<xs:element name="Saksnummer" type="SaksnummerType"/>
+	
 	<xs:complexType name="SaksnummerListe">
 		<xs:sequence>
 			<xs:element name="saksnummer" type="SaksnummerType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
+	
 	<xs:complexType name="SaksnummerType">
 		<xs:sequence>
 			<xs:element name="saksaar" minOccurs="1" maxOccurs="1" type="xs:integer"/>
 			<xs:element name="sakssekvensnummer" minOccurs="1" maxOccurs="1" type="xs:integer"/>
 		</xs:sequence>
 	</xs:complexType>
+	
 	<xs:simpleType name="StatusTypeType">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="velykket"/>
@@ -38,6 +41,7 @@
 			<xs:enumeration value="manglendeOpplysninger"/>
 		</xs:restriction>
 	</xs:simpleType>
+	
 	<xs:complexType name="StatusTypeListe">
 		<xs:sequence>
 			<xs:element name="statustype" type="StatusTypeType" minOccurs="0" maxOccurs="unbounded"/>

--- a/Schema/V2/no.ks.fiks.matrikkelfoering.v2.kvittering.xsd
+++ b/Schema/V2/no.ks.fiks.matrikkelfoering.v2.kvittering.xsd
@@ -1,33 +1,27 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://rep.geointegrasjon.no/Matrikkel/foeringskvittering/v2" xmlns:kv="http://rep.geointegrasjon.no/Matrikkel/foeringskvittering/v2" xmlns:mf="http://rep.geointegrasjon.no/Matrikkel/foering/v2" elementFormDefault="qualified" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" >
-
-	<xs:import namespace="http://rep.geointegrasjon.no/Matrikkel/foering/v2" schemaLocation="https://ks-no.github.io/files/kvitteringmatrikkelfoeringv2.xsd"/>
-	<!--For lokal test, comment out later-->
-	<!--<xs:import namespace="matrikkelfoering.xsd"/>-->
-
-	<!--<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://rep.geointegrasjon.no/Matrikkel/foeringskvittering/v2" xmlns:kv="http://rep.geointegrasjon.no/Matrikkel/foeringskvittering/v2" xmlns:mf="http://rep.geointegrasjon.no/Matrikkel/foering/v2" elementFormDefault="qualified">-->
-
-	<!-- Generert av MetaTrans(1.1.0.0) - 25.03.2022 09:16:26-->
-	<!-- -manually fixed import 31.03.2022 -->
-	<xs:element name="KvitteringMatrikkel" type="kv:KvitteringMatrikkelType"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://rep.geointegrasjon.no/Matrikkel/foeringskvittering/v2" xmlns:mf="http://rep.geointegrasjon.no/Matrikkel/foering/v2" elementFormDefault="qualified" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" >
+	
+	<xs:element name="KvitteringMatrikkel" type="KvitteringMatrikkelType"/>
+	
 	<xs:complexType name="KvitteringMatrikkelListe">
 		<xs:sequence>
-			<xs:element name="kvitteringmatrikkel" type="kv:KvitteringMatrikkelType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="kvitteringmatrikkel" type="KvitteringMatrikkelType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
+	
 	<xs:complexType name="KvitteringMatrikkelType">
 		<xs:sequence>
-			<xs:element name="saksnummer" minOccurs="1" maxOccurs="1" type="kv:SaksnummerType"/>
-			<xs:element name="status" minOccurs="1" maxOccurs="1" type="kv:StatusTypeType"/>
+			<xs:element name="saksnummer" minOccurs="1" maxOccurs="1" type="SaksnummerType"/>
+			<xs:element name="status" minOccurs="1" maxOccurs="1" type="StatusTypeType"/>
 			<xs:element name="melding" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string"/>
 			<xs:element name="tiltak" minOccurs="0" maxOccurs="1" nillable="true" type="mf:TiltakListe"/>
 			<xs:element name="byggIdent" minOccurs="0" maxOccurs="1" nillable="true" type="mf:ByggIdentListe"/>
 		</xs:sequence>
 	</xs:complexType>
-	<xs:element name="Saksnummer" type="kv:SaksnummerType"/>
+	<xs:element name="Saksnummer" type="SaksnummerType"/>
 	<xs:complexType name="SaksnummerListe">
 		<xs:sequence>
-			<xs:element name="saksnummer" type="kv:SaksnummerType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="saksnummer" type="SaksnummerType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="SaksnummerType">
@@ -46,7 +40,7 @@
 	</xs:simpleType>
 	<xs:complexType name="StatusTypeListe">
 		<xs:sequence>
-			<xs:element name="statustype" type="kv:StatusTypeType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="statustype" type="StatusTypeType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Ryddet i xsd-skjema mtp import av felles xsd og slettet typer som ikke er i bruk

Importerer felles skjema som nå følger med som en del av protokollen samt ryddet litt. F.eks. var det 2 typer i kvitteringen som ikke er i bruk. Kvittering xsd importerte også seg selv og brukte namespace i stedet for å bare bruke internt. 