### PR TITLE
Utbedringer til kvittering for å gi bedre informasjon tilbake

### DIFF
--- a/Schema/V2/no.ks.fiks.matrikkelfoering.v2.grunnlag.xsd
+++ b/Schema/V2/no.ks.fiks.matrikkelfoering.v2.grunnlag.xsd
@@ -122,7 +122,7 @@
       <xs:element name="harHeis" minOccurs="0" maxOccurs="1" nillable="true" type="xs:boolean"/>
       <xs:element name="endring" minOccurs="1" maxOccurs="1" type="mf:EndringsstatusType"/>
       <xs:element name="representasjonsPunkt" minOccurs="0" maxOccurs="1" nillable="true" type="fellesgeometrins:Punkt"/>
-      <xs:element name="tiltakid" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string"/>
+      <xs:element name="tiltakid" minOccurs="1" maxOccurs="1" nillable="true" type="xs:string"/>
       <xs:element name="byggIdent" minOccurs="0" maxOccurs="1" nillable="true" type="mf:ByggIdentType"/>
     </xs:sequence>
   </xs:complexType>

--- a/Schema/V2/no.ks.fiks.matrikkelfoering.v2.kvittering.xsd
+++ b/Schema/V2/no.ks.fiks.matrikkelfoering.v2.kvittering.xsd
@@ -56,7 +56,7 @@
 	<xs:simpleType name="OverordnetStatus">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="ok"/>
-			<xs:enumeration value="ikkeOk"/>
+			<xs:enumeration value="feilet"/>
 		</xs:restriction>
 	</xs:simpleType>
 

--- a/Schema/V2/no.ks.fiks.matrikkelfoering.v2.kvittering.xsd
+++ b/Schema/V2/no.ks.fiks.matrikkelfoering.v2.kvittering.xsd
@@ -33,7 +33,7 @@
 		<xs:sequence>
 			<xs:element name="status" type="Status"/>
 			<xs:element name="melding" minOccurs="0" nillable="true" type="xs:string"/>
-			<xs:element name="tiltak" minOccurs="0" nillable="true" type="mf:TiltakType"/>
+			<xs:element name="tiltakid" nillable="true" type="xs:string"/>
 			<xs:element name="byggIdent" minOccurs="0" nillable="true" type="mf:ByggIdentType"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -48,17 +48,15 @@
 	<xs:simpleType name="Status">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="velykket"/>
-			<xs:enumeration value="delvisFoert"/>
+			<xs:enumeration value="feilet"/>
 			<xs:enumeration value="skalIkkeMatrikkelfoeres"/>
-			<xs:enumeration value="manglendeOpplysninger"/>
 		</xs:restriction>
 	</xs:simpleType>
 
 	<xs:simpleType name="OverordnetStatus">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="velykket"/>
-			<xs:enumeration value="delvisFoert"/>
-			<xs:enumeration value="ikkeFoert"/>
+			<xs:enumeration value="ok"/>
+			<xs:enumeration value="ikkeOk"/>
 		</xs:restriction>
 	</xs:simpleType>
 

--- a/Schema/V2/no.ks.fiks.matrikkelfoering.v2.kvittering.xsd
+++ b/Schema/V2/no.ks.fiks.matrikkelfoering.v2.kvittering.xsd
@@ -17,7 +17,9 @@
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="saksnummer" type="Saksnummer"/>
-			<xs:element name="kvitteringer" maxOccurs="unbounded" nillable="true" type="Kvittering"/>
+			<xs:element name="status" type="OverordnetStatus"/>
+			<xs:element name="melding" minOccurs="0" nillable="true" type="xs:string"/>
+			<xs:element name="kvitteringer" minOccurs="0" maxOccurs="unbounded" nillable="true" type="Kvittering"/>
 		</xs:sequence>
 	</xs:complexType>
 
@@ -29,7 +31,7 @@
 			</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="status" type="Statustype"/>
+			<xs:element name="status" type="Status"/>
 			<xs:element name="melding" minOccurs="0" nillable="true" type="xs:string"/>
 			<xs:element name="tiltak" minOccurs="0" nillable="true" type="mf:TiltakType"/>
 			<xs:element name="byggIdent" minOccurs="0" nillable="true" type="mf:ByggIdentType"/>
@@ -43,12 +45,20 @@
 		</xs:sequence>
 	</xs:complexType>
 
-	<xs:simpleType name="Statustype">
+	<xs:simpleType name="Status">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="velykket"/>
 			<xs:enumeration value="delvisFoert"/>
 			<xs:enumeration value="skalIkkeMatrikkelfoeres"/>
 			<xs:enumeration value="manglendeOpplysninger"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="OverordnetStatus">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="velykket"/>
+			<xs:enumeration value="delvisFoert"/>
+			<xs:enumeration value="ikkeFoert"/>
 		</xs:restriction>
 	</xs:simpleType>
 

--- a/Schema/V2/no.ks.fiks.matrikkelfoering.v2.kvittering.xsd
+++ b/Schema/V2/no.ks.fiks.matrikkelfoering.v2.kvittering.xsd
@@ -1,39 +1,49 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <xs:schema
 		xmlns="http://rep.geointegrasjon.no/Matrikkel/foeringskvittering/v2"
-		xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-		targetNamespace="http://rep.geointegrasjon.no/Matrikkel/foeringskvittering/v2" 
-		xmlns:mf="http://rep.geointegrasjon.no/Matrikkel/foering/v2" 
-		elementFormDefault="qualified" 
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" >
+		xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		targetNamespace="http://rep.geointegrasjon.no/Matrikkel/foeringskvittering/v2"
+		xmlns:mf="http://rep.geointegrasjon.no/Matrikkel/foering/v2"
+		elementFormDefault="qualified">
 
-	<xs:element name="KvitteringMatrikkel" type="KvitteringMatrikkelType"/>
-	<xs:element name="Saksnummer" type="SaksnummerType"/>
+	<xs:element name="KvitteringMatrikkel" type="KvitteringMatrikkel"/>
+	<xs:element name="Saksnummer" type="Saksnummer"/>
 
-	<xs:complexType name="KvitteringMatrikkelType">
+	<xs:complexType name="KvitteringMatrikkel">
+		<xs:annotation>
+			<xs:documentation>
+				Listen kvittering av typen ByggKvittering inneholder status pr enhet. 
+			</xs:documentation>
+		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="saksnummer" minOccurs="1" maxOccurs="1" type="SaksnummerType"/>
-			<xs:element name="status" minOccurs="1" maxOccurs="1" type="StatusTypeType"/>
-			<xs:element name="melding" minOccurs="0" maxOccurs="1" nillable="true" type="xs:string"/>
-			<xs:element name="tiltak" minOccurs="0" maxOccurs="1" nillable="true" type="mf:TiltakListe"/>
-			<xs:element name="byggIdent" minOccurs="0" maxOccurs="1" nillable="true" type="mf:ByggIdentListe"/>
+			<xs:element name="saksnummer" type="Saksnummer"/>
+			<xs:element name="kvitteringer" maxOccurs="unbounded" nillable="true" type="Kvittering"/>
 		</xs:sequence>
 	</xs:complexType>
 
-	<xs:complexType name="SaksnummerListe">
+	<xs:complexType name="Kvittering">
+		<xs:annotation>
+			<xs:documentation>
+				ByggKvittering inneholder status pr enhet. Status viser om det var vellykket registrert eller ikke.
+				Melding kan brukes for å gi informasjon hvorfor det ikke var vellykket. 
+			</xs:documentation>
+		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="saksnummer" type="SaksnummerType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="status" type="Statustype"/>
+			<xs:element name="melding" minOccurs="0" nillable="true" type="xs:string"/>
+			<xs:element name="tiltak" minOccurs="0" nillable="true" type="mf:TiltakType"/>
+			<xs:element name="byggIdent" minOccurs="0" nillable="true" type="mf:ByggIdentType"/>
 		</xs:sequence>
 	</xs:complexType>
 
-	<xs:complexType name="SaksnummerType">
+	<xs:complexType name="Saksnummer">
 		<xs:sequence>
-			<xs:element name="saksaar" minOccurs="1" maxOccurs="1" type="xs:integer"/>
-			<xs:element name="sakssekvensnummer" minOccurs="1" maxOccurs="1" type="xs:integer"/>
+			<xs:element name="saksaar" type="xs:integer"/>
+			<xs:element name="sakssekvensnummer" type="xs:integer"/>
 		</xs:sequence>
 	</xs:complexType>
 
-	<xs:simpleType name="StatusTypeType">
+	<xs:simpleType name="Statustype">
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="velykket"/>
 			<xs:enumeration value="delvisFoert"/>


### PR DESCRIPTION
Ref møtet 13.12.2023 ser vi at kvittering melding bør inneholde nok informasjon om hva som gikk bra og hva som gikk galt, slik at mottaker av kvittering kan vite hva som må sendes inn på nytt med forbedringer. 
Se også issue #11 

Valgte å endrre status på "øverste" nivå til en oppsummering av om det var vellykket eller ikke.
Tanken er at hvis alt gikk bra så er det vellykket, var det noe som ikke gikk bra så er det delvisFoert, og hvis ingenting kunne føres så sender man en tom liste tilbake, setter status til ikkeFoert og gir en tekst tilbake i melding feltet hva som gikk galt?

```
	<xs:simpleType name="OverordnetStatus">
		<xs:restriction base="xs:string">
			<xs:enumeration value="velykket"/>
			<xs:enumeration value="delvisFoert"/>
			<xs:enumeration value="ikkeFoert"/>
		</xs:restriction>
	</xs:simpleType>
```

Så setter man Status pr kvittering element i listen som det stod fra før:

```
	<xs:simpleType name="Status">
		<xs:restriction base="xs:string">
			<xs:enumeration value="velykket"/>
			<xs:enumeration value="delvisFoert"/>
			<xs:enumeration value="skalIkkeMatrikkelfoeres"/>
			<xs:enumeration value="manglendeOpplysninger"/>
		</xs:restriction>
	</xs:simpleType>
```
---

Edit 10.01.2024:
Vi konkluderte med at regelen skal være at hvis man får tilbake en kvittering med noen bygninger som ikke ble ført eller delvis ført, så skal bare de som korrigeres sendes på nytt. 
Regler som dette kan ikke beskrives i xsd-skjema og vil dokumenteres i stedet med protokollen.
