### PR TITLE
Endret fra xs:integer til xs:long

### DIFF
--- a/Schema/V2/no.ks.fiks.matrikkelfoering.v2.grunnlag.xsd
+++ b/Schema/V2/no.ks.fiks.matrikkelfoering.v2.grunnlag.xsd
@@ -105,7 +105,7 @@
   </xs:complexType>
   <xs:complexType name="ByggIdentType">
     <xs:sequence>
-      <xs:element name="bygningsnummer" minOccurs="1" maxOccurs="1" type="xs:integer"/>
+      <xs:element name="bygningsnummer" minOccurs="1" maxOccurs="1" type="xs:long"/>
       <xs:element name="bygningsloepenummer" minOccurs="0" maxOccurs="1" nillable="true" type="xs:integer"/>
     </xs:sequence>
   </xs:complexType>


### PR DESCRIPTION
Ref issue #17 
Hvis det ikke var nok med xs:integer som blir til 32-bit integer så endrer vi til xs:long. 
Mappingverktøy har hatt problem med xs:integer og vi endret til xs:int i Fiks Arkiv skjemaene nettopp pga dette.